### PR TITLE
Bigfix - Fix yearsOfExperience comparision

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
         advocate.city.includes(searchTerm) ||
         advocate.degree.includes(searchTerm) ||
         advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        advocate.yearsOfExperience === Number(searchTerm)
       );
     });
 


### PR DESCRIPTION
`yearsOfExperience` is not a string, and thus, `advocate.yearsOfExperience.includes` threw an error - which then broke the filtering feature.  This PR fixes the issue by casting `searchTerm` into a `Number` and then using that to compare with `yearsOfExperience`